### PR TITLE
Add cli argument to turn off smart file checking

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,8 +4,9 @@
 
 .prettierignore
 .prettierrc.json
-tsconfig.json
 .gitignore
+README.md
+TODO.txt
+tsconfig.json
 yarn.lock
 
-TODO.txt

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Default behavior
 
-Prepends `// @ts-nocheck` to the top of every .js, .jsx, .ts and .tsx file in a given directory.
+Prepends `// @ts-nocheck` to the top of all .js, .jsx, .ts and .tsx files in a given directory which do not already have one.
 
 ## Usage
 
@@ -21,13 +21,13 @@ Options configuration:
   --jsx-off               Disable adding nocheck to js files
   --ts-off                Disable adding nocheck to ts files
   --tsx-off               Disable adding nocheck to tsx files
-  --smartCheck-off        Add nocheck to all js, jsx, ts, tsx files even if it already has one
+  --smart-check-off        Add nocheck to all js, jsx, ts, tsx files even if it already has one
 ```
 
 ## Motivation
 
-Changing the file extension of all your .js/.jsx files to .ts/.tsx at once at the start of your migration comes with the benefit of much more readable git diffs in the future. For example, if a file is renamed (file extension changed) and then enough changes are made (added TS types), git will list this as two seperate files, a file deletion (the JS file) + a brand new file (TS file). This makes the diffs hard to compare.
+Changing the file extension of all your .js/.jsx files to .ts/.tsx at once at the start of your migration comes with the benefit of much more readable Git diffs in the future. For example, if a file is renamed (aka extension changed) and then enough file changes are made, Git will list this as two seperate files, a file deletion (JS file) + a brand new file (TS file). This makes the diffs hard to compare.
 
-However, changing all file extensions to .ts/.tsx at once obviously prevents you from compiling until types for all files are added. Adding [`// @ts-nocheck`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#-ts-nocheck-in-typescript-files) to the top of all these files lets you migrate to TS with cleaner diffs.
+However, changing all file extensions to .ts/.tsx at once obviously prevents you from compiling until types for all files are added. Adding [`// @ts-nocheck`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#-ts-nocheck-in-typescript-files) to the top of all your files can help ease the pain of a JS to TS migration.
 
 Pairs well with tools such as [js-to-tsx](https://github.com/markogresak/js-to-tsx).

--- a/dist/cliParser.d.ts
+++ b/dist/cliParser.d.ts
@@ -4,6 +4,7 @@ export interface IConfig {
     jsx: boolean;
     ts: boolean;
     tsx: boolean;
+    smartCheck: boolean;
     path: string;
 }
 export declare const cliParser: (args: string[]) => IConfig | null;

--- a/dist/cliParser.js
+++ b/dist/cliParser.js
@@ -7,6 +7,7 @@ const cliConfigOptionsMap = new Map([
     ['--js-off', 'js'],
     ['--tsx-off', 'tsx'],
     ['--ts-off', 'ts'],
+    ['--smart-check-off', 'smartCheck'],
 ]);
 const cliParser = (args) => {
     if (!args.length) {
@@ -18,6 +19,7 @@ const cliParser = (args) => {
         js: true,
         tsx: true,
         ts: true,
+        smartCheck: true,
         path: args[args.length - 1],
     };
     for (let i = 0; i < args.length - 1; ++i) {

--- a/dist/fileHandler.d.ts
+++ b/dist/fileHandler.d.ts
@@ -1,0 +1,2 @@
+import { IConfig } from './cliParser';
+export declare const dfs: (dir: string, config: IConfig) => Promise<void>;

--- a/dist/fileHandler.js
+++ b/dist/fileHandler.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.dfs = void 0;
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const addNocheck = (filePath, fileLines, config) => {
+    if (config.smartCheck) {
+        const firstLine = fileLines[0];
+        if (firstLine.trim().startsWith('//')) {
+            const commentContent = firstLine.substring(firstLine.indexOf('//') + 2);
+            if (commentContent.trim().split(' ')[0] === '@ts-nocheck') {
+                return;
+            }
+        }
+    }
+    fileLines.unshift('// @ts-nocheck');
+    fs_1.default.writeFile(filePath, fileLines.join('\n'), (err) => {
+        if (err)
+            console.error(err);
+    });
+};
+const getFileLinesAsync = (filePath) => {
+    return new Promise((resolve, reject) => {
+        fs_1.default.readFile(filePath, 'utf8', (err, file) => {
+            if (err)
+                reject(err);
+            resolve(file.toString().split('\n'));
+        });
+    });
+};
+const dfs = (dir, config) => __awaiter(void 0, void 0, void 0, function* () {
+    const filesInDir = fs_1.default.readdirSync(dir);
+    for (let i = 0; i < filesInDir.length; ++i) {
+        const currPath = path_1.default.join(dir, filesInDir[i]);
+        const stat = fs_1.default.lstatSync(currPath);
+        if (stat.isDirectory()) {
+            (0, exports.dfs)(currPath, config);
+        }
+        else {
+            const { ext } = path_1.default.parse(currPath);
+            if (config[ext.substring(1)]) {
+                const lines = yield getFileLinesAsync(currPath);
+                addNocheck(currPath, lines, config);
+            }
+        }
+    }
+});
+exports.dfs = dfs;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,67 +1,9 @@
 #!/usr/bin/env node
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-const fs_1 = __importDefault(require("fs"));
-const path_1 = __importDefault(require("path"));
 const cliParser_1 = require("./cliParser");
-const smartCheck = true;
-const addNocheck = (filePath, fileLines) => {
-    if (smartCheck) {
-        const firstLine = fileLines[0];
-        if (firstLine.trim().startsWith('//')) {
-            const commentContent = firstLine.substring(firstLine.indexOf('//') + 2);
-            if (commentContent.trim().split(' ')[0] === '@ts-nocheck') {
-                console.log('has a nocheck already');
-                return;
-            }
-        }
-    }
-    fileLines.unshift('// @ts-nocheck');
-    fs_1.default.writeFile(filePath, fileLines.join('\n'), (err) => {
-        if (err)
-            console.error(err);
-    });
-};
-const getFileLinesAsync = (filePath) => {
-    return new Promise((resolve, reject) => {
-        fs_1.default.readFile(filePath, 'utf8', (err, file) => {
-            if (err)
-                reject(err);
-            resolve(file.toString().split('\n'));
-        });
-    });
-};
-const dfs = (dir, config) => __awaiter(void 0, void 0, void 0, function* () {
-    const filesInDir = fs_1.default.readdirSync(dir);
-    for (let i = 0; i < filesInDir.length; ++i) {
-        const currPath = path_1.default.join(dir, filesInDir[i]);
-        const stat = fs_1.default.lstatSync(currPath);
-        if (stat.isDirectory()) {
-            dfs(currPath, config);
-        }
-        else {
-            const { ext } = path_1.default.parse(currPath);
-            if (config[ext.substring(1)]) {
-                const lines = yield getFileLinesAsync(currPath);
-                addNocheck(currPath, lines);
-            }
-        }
-    }
-});
-const cliArgs = process.argv.slice(2);
-const config = (0, cliParser_1.cliParser)(cliArgs);
+const fileHandler_1 = require("./fileHandler");
+const config = (0, cliParser_1.cliParser)(process.argv.slice(2));
 if (config) {
-    dfs(config.path, config);
+    (0, fileHandler_1.dfs)(config.path, config);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-nocheck",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Painlessly add `@ts-nocheck` to the files you need it in.",
   "main": "./dist/index.js",
   "bin": "./dist/index.js",

--- a/src/cliParser.ts
+++ b/src/cliParser.ts
@@ -4,6 +4,7 @@ export interface IConfig {
   jsx: boolean;
   ts: boolean;
   tsx: boolean;
+  smartCheck: boolean;
   path: string;
 }
 
@@ -12,6 +13,7 @@ const cliConfigOptionsMap = new Map([
   ['--js-off', 'js'],
   ['--tsx-off', 'tsx'],
   ['--ts-off', 'ts'],
+  ['--smart-check-off', 'smartCheck'],
 ]);
 
 export const cliParser = (args: string[]): IConfig | null => {
@@ -19,12 +21,13 @@ export const cliParser = (args: string[]): IConfig | null => {
     console.error(`ERROR: no directory path provide.`);
   }
 
-  const seen = new Set<string>(); // make sure there's no repeats args
+  const seen = new Set<string>(); // make sure there's no repeated args
   const config: IConfig = {
     jsx: true,
     js: true,
     tsx: true,
     ts: true,
+    smartCheck: true,
     path: args[args.length - 1],
   };
 

--- a/src/fileHandler.ts
+++ b/src/fileHandler.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import { FileExtensionKey, IConfig } from './cliParser';
+
+const addNocheck = (filePath: string, fileLines: string[], config: IConfig) => {
+  // smartCheck is on as default.
+  if (config.smartCheck) {
+    const firstLine = fileLines[0];
+    if (firstLine.trim().startsWith('//')) {
+      const commentContent = firstLine.substring(firstLine.indexOf('//') + 2);
+
+      if (commentContent.trim().split(' ')[0] === '@ts-nocheck') {
+        return;
+      }
+    }
+  }
+  fileLines.unshift('// @ts-nocheck');
+  fs.writeFile(filePath, fileLines.join('\n'), (err) => {
+    if (err) console.error(err);
+  });
+};
+
+const getFileLinesAsync = (filePath: string): Promise<string[]> => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (err, file) => {
+      if (err) reject(err);
+
+      // resolve promise with array of lines
+      resolve(file.toString().split('\n'));
+    });
+  });
+};
+
+export const dfs = async (dir: string, config: IConfig): Promise<void> => {
+  const filesInDir = fs.readdirSync(dir);
+
+  for (let i = 0; i < filesInDir.length; ++i) {
+    const currPath = path.join(dir, filesInDir[i]);
+    const stat = fs.lstatSync(currPath);
+
+    if (stat.isDirectory()) {
+      dfs(currPath, config);
+    } else {
+      // Add no-check line to file iff extension is specified in config.
+      const { ext } = path.parse(currPath);
+      if (config[ext.substring(1) as FileExtensionKey]) {
+        const lines = await getFileLinesAsync(currPath);
+        addNocheck(currPath, lines, config);
+      }
+    }
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,8 @@
-import fs from 'fs';
-import path from 'path';
-import { cliParser, FileExtensionKey, IConfig } from './cliParser';
+import { cliParser } from './cliParser';
+import { dfs } from './fileHandler';
 
-const smartCheck = true;
+const config = cliParser(process.argv.slice(2));
 
-const addNocheck = (filePath: string, fileLines: string[]) => {
-  // fileLines.splice(0, 1); // DEV
-
-  // smartCheck is on by default. Options coming in future release.
-  if (smartCheck) {
-    const firstLine = fileLines[0];
-    if (firstLine.trim().startsWith('//')) {
-      const commentContent = firstLine.substring(firstLine.indexOf('//') + 2);
-      if (commentContent.trim().split(' ')[0] === '@ts-nocheck') {
-        console.log('has a nocheck already');
-        return;
-      }
-    }
-  }
-  fileLines.unshift('// @ts-nocheck');
-  fs.writeFile(filePath, fileLines.join('\n'), (err) => {
-    if (err) console.error(err);
-  });
-};
-
-const getFileLinesAsync = (filePath: string): Promise<string[]> => {
-  return new Promise((resolve, reject) => {
-    fs.readFile(filePath, 'utf8', (err, file) => {
-      if (err) reject(err);
-      // resolve promise with array of lines
-      resolve(file.toString().split('\n'));
-    });
-  });
-};
-
-const dfs = async (dir: string, config: IConfig) => {
-  const filesInDir = fs.readdirSync(dir);
-  for (let i = 0; i < filesInDir.length; ++i) {
-    const currPath = path.join(dir, filesInDir[i]);
-    const stat = fs.lstatSync(currPath);
-
-    if (stat.isDirectory()) {
-      dfs(currPath, config);
-    } else {
-      // Add no-check line to file iff specified in config.
-      const { ext } = path.parse(currPath);
-      if (config[ext.substring(1) as FileExtensionKey]) {
-        const lines = await getFileLinesAsync(currPath);
-        addNocheck(currPath, lines);
-      }
-    }
-  }
-};
-
-const cliArgs = process.argv.slice(2);
-const config = cliParser(cliArgs);
 if (config) {
   dfs(config.path, config);
 }


### PR DESCRIPTION
- Users can pass the `--smart-check-off` flag to forcefully add `// @ts-nocheck` to all js, jsx, ts, tsx files even if they already have a nocheck at the top. 